### PR TITLE
Add folder import support

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -8,7 +8,7 @@ import {
   generatePageImports,
   generateFolderImports,
   writeImportBlocksToFile 
-} from './src/tf_import_block_generator.ts';
+} from './src/tf_import_block_generator';
 
 async function main() {
   const PORT_CLIENT_ID = process.env.PORT_CLIENT_ID;

--- a/main.ts
+++ b/main.ts
@@ -8,7 +8,7 @@ import {
   generatePageImports,
   generateFolderImports,
   writeImportBlocksToFile 
-} from './src/tf_import_block_generator';
+} from './src/tf_import_block_generator.ts';
 
 async function main() {
   const PORT_CLIENT_ID = process.env.PORT_CLIENT_ID;
@@ -33,6 +33,8 @@ async function main() {
     const webhooks = await client.get('/webhooks');
     console.log('fetching pages');
     const pages = await client.get('/pages');
+    console.log('fetching folders');
+    const folders = await client.get('/sidebars/catalog');
 
 
     console.log('generating tf import files');
@@ -42,9 +44,9 @@ async function main() {
     const integrationImports = await generateIntegrationImports(integrations.integrations);
     const webhookImports = await generateWebhookImports(webhooks.integrations);
     const pageImports = await generatePageImports(pages.pages);
-    const folderImports = await generateFolderImports(pages.pages);
+    const folderImports = await generateFolderImports(folders);
 
-    await Promise.all([
+    await Promise.all([ 
         writeImportBlocksToFile(actionImports, 'action_imports.tf'),
         writeImportBlocksToFile(blueprintImports, 'blueprint_imports.tf'),
         writeImportBlocksToFile(scorecardImports, 'scorecard_imports.tf'),

--- a/main.ts
+++ b/main.ts
@@ -6,6 +6,7 @@ import {
   generateIntegrationImports,
   generateWebhookImports,
   generatePageImports,
+  generateFolderImports,
   writeImportBlocksToFile 
 } from './src/tf_import_block_generator';
 
@@ -41,6 +42,7 @@ async function main() {
     const integrationImports = await generateIntegrationImports(integrations.integrations);
     const webhookImports = await generateWebhookImports(webhooks.integrations);
     const pageImports = await generatePageImports(pages.pages);
+    const folderImports = await generateFolderImports(pages.pages);
 
     await Promise.all([
         writeImportBlocksToFile(actionImports, 'action_imports.tf'),
@@ -48,7 +50,8 @@ async function main() {
         writeImportBlocksToFile(scorecardImports, 'scorecard_imports.tf'),
         writeImportBlocksToFile(integrationImports, 'integration_imports.tf'),
         writeImportBlocksToFile(webhookImports, 'webhook_imports.tf'),
-        writeImportBlocksToFile(pageImports, 'page_imports.tf')
+        writeImportBlocksToFile(pageImports, 'page_imports.tf'),
+        writeImportBlocksToFile(folderImports, 'folder_imports.tf')
     ]);
 
   } catch (error) {

--- a/src/tf_import_block_generator.ts
+++ b/src/tf_import_block_generator.ts
@@ -29,7 +29,11 @@ interface PortWebhook {
 
 interface PortPage {
     identifier: string;
-    parent?: string | null;
+}
+
+interface PortFolder {
+    identifier: string;
+    title: string;
 }
 
 export async function generateActionImports(actions: PortAction[]): Promise<string[]> {
@@ -110,31 +114,6 @@ export async function generatePageImports(pages: PortPage[]): Promise<string[]> 
     return importBlocks;
 }
 
-
-
-export async function generateFolderImports(pages: PortPage[]): Promise<string[]> {
-    const importBlocks: string[] = [];
-    // to remove duplicates, since page.parent can contain several duplicates
-    const seenParents = new Set<string>();
-
-    pages.forEach((page: PortPage) => {
-        // filter out folders that are null or start with digit (invalid HCL syntax)
-        if (page.parent && 
-            !/^\d/.test(page.parent) &&
-            !seenParents.has(page.parent)) {
-
-            seenParents.add(page.parent);
-            importBlocks.push(
-                `import {
-        to = port_folder.${page.parent}
-        id = "${page.parent}" 
-    }`
-            );
-        }
-    });
-    return importBlocks;
-}
-
 export async function generateBlueprintImports(blueprints: PortBlueprint[]): Promise<string[]> {
     const importBlocks: string[] = [];
     
@@ -147,6 +126,27 @@ export async function generateBlueprintImports(blueprints: PortBlueprint[]): Pro
         );
     });
     
+    return importBlocks;
+}
+
+export async function generateFolderImports(sidebarResponse: PortSidebar): Promise<string[]> {
+    const importBlocks: string[] = [];
+
+    sidebarResponse.sidebar.items.forEach((item) => {
+        // skip pages and filter out folder identifiers that start with digit (invalid HCL syntax)
+        if (
+            item.sidebarType === "folder" &&
+            !/^\d/.test(item.identifier)
+        ) {
+            importBlocks.push(
+                `import {
+    to = port_folder.${item.identifier}
+    id = "${item.identifier}" 
+}`
+            );
+        }
+    });
+
     return importBlocks;
 }
 

--- a/src/tf_import_block_generator.ts
+++ b/src/tf_import_block_generator.ts
@@ -29,6 +29,7 @@ interface PortWebhook {
 
 interface PortPage {
     identifier: string;
+    parent?: string | null;
 }
 
 export async function generateActionImports(actions: PortAction[]): Promise<string[]> {
@@ -102,6 +103,31 @@ export async function generatePageImports(pages: PortPage[]): Promise<string[]> 
                 `import {
         to = port_page.${page.identifier}
         id = "${page.identifier}" 
+    }`
+            );
+        }
+    });
+    return importBlocks;
+}
+
+
+
+export async function generateFolderImports(pages: PortPage[]): Promise<string[]> {
+    const importBlocks: string[] = [];
+    // to remove duplicates, since page.parent can contain several duplicates
+    const seenParents = new Set<string>();
+
+    pages.forEach((page: PortPage) => {
+        // filter out folders that are null or start with numberal (invalid HCL syntax)
+        if (page.parent && 
+            !/^\d/.test(page.parent) &&
+            !seenParents.has(page.parent)) {
+
+            seenParents.add(page.parent);
+            importBlocks.push(
+                `import {
+        to = port_page.${page.parent}
+        id = "${page.parent}" 
     }`
             );
         }

--- a/src/tf_import_block_generator.ts
+++ b/src/tf_import_block_generator.ts
@@ -126,7 +126,7 @@ export async function generateFolderImports(pages: PortPage[]): Promise<string[]
             seenParents.add(page.parent);
             importBlocks.push(
                 `import {
-        to = port_page.${page.parent}
+        to = port_folder.${page.parent}
         id = "${page.parent}" 
     }`
             );

--- a/src/tf_import_block_generator.ts
+++ b/src/tf_import_block_generator.ts
@@ -118,7 +118,7 @@ export async function generateFolderImports(pages: PortPage[]): Promise<string[]
     const seenParents = new Set<string>();
 
     pages.forEach((page: PortPage) => {
-        // filter out folders that are null or start with numberal (invalid HCL syntax)
+        // filter out folders that are null or start with digit (invalid HCL syntax)
         if (page.parent && 
             !/^\d/.test(page.parent) &&
             !seenParents.has(page.parent)) {


### PR DESCRIPTION
- added method to extract folder identifier from page (from .parent)
- dedups duplicates (as several pages contain the same parent)
- filters out .parent values that are null
- removes folder entries that begin with a digit (invalid HCL syntax)