### PR TITLE
Add whitelist options for pages, actions, and blueprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ terraform plan
 | Option | Description |
 |--------|-------------|
 | `-m, --migration-mode` | Display warnings for common migration issues |
-| `--auto-fix` | Track fixes for reporting (entity types, relation titles, page ordering) |
+| `--auto-fix` | Track fixes for reporting (relation titles, page ordering) |
 | `--report` | Generate `migration_report.md` |
 | `--generate-fix-script` | Generate `fix_generated.sh` |
 | `--terraform` | Run terraform init, plan, generate config, and apply fixes automatically |
@@ -85,6 +85,9 @@ terraform plan
 | `--exclude-system-blueprints` | Skip system blueprints (`_*` prefixed) |
 | `--exclude-ai-pages` | Skip pages with AI agent widgets |
 | `--exclude <patterns...>` | Pattern-based exclusion (e.g., `"integration:GitHub-*"`) |
+| `--include-pages <ids...>` | Whitelist: only export these page IDs |
+| `--include-actions <ids...>` | Whitelist: only export these action IDs |
+| `--include-blueprints <ids...>` | Whitelist: only export these blueprint IDs |
 | `-b, --export-entities-for-blueprints <ids>` | Export entities for specific blueprints |
 | `-p, --provider-alias <alias>` | Provider alias (default: `port-labs`) |
 
@@ -94,7 +97,6 @@ The `fix_generated.sh` script fixes issues in `generated.tf` that Terraform cann
 
 | Issue | Fix |
 |-------|-----|
-| Entity page types | `type = "entity"` → `type = "blueprint-entities"` |
 | jq_condition expressions | `expressions = null` → `expressions = []` |
 
 ## Migration Warnings
@@ -119,6 +121,16 @@ port-tf-import -m --exclude-github-integrations --exclude-ai-pages
 
 # Pattern-based exclusion
 port-tf-import -m --exclude "integration:GitHub-*" --exclude "blueprint:_*"
+```
+
+Include only specific resources (whitelist):
+
+```bash
+# Only export specific pages
+port-tf-import --include-pages my-page-id another-page-id
+
+# Only export specific blueprints and actions
+port-tf-import --include-blueprints service environment --include-actions deploy-service
 ```
 
 ## Environment Variables

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ import {
   filterIntegrations,
   filterBlueprints,
   filterPages,
+  filterActions,
   generateFixScript,
   generateMigrationReport,
 } from './tf_import_block_generator';
@@ -38,11 +39,14 @@ program
   .option('-b, --export-entities-for-blueprints <ids>', 'Comma-separated list of blueprint IDs to fetch entities for', (val) => val.split(',').map(bp => bp.trim()).filter(Boolean))
   .option('-p, --provider-alias <alias>', 'Terraform provider alias to use in import blocks (default: port-labs, can also be set via PORT_PROVIDER_ALIAS env var)')
   .option('-m, --migration-mode', 'Enable migration mode with warnings for common migration issues')
-  .option('--auto-fix', 'Automatically fix known issues during generation (entity page types, null relation titles, page ordering)')
+  .option('--auto-fix', 'Automatically fix known issues during generation (null relation titles, page ordering)')
   .option('--exclude-github-integrations', 'Exclude GitHub integrations from import (they require manual reconfiguration)')
   .option('--exclude-system-blueprints', 'Exclude system blueprints (_* prefixed) from import')
   .option('--exclude-ai-pages', 'Exclude pages containing AI agent widgets')
   .option('--exclude <patterns...>', 'Pattern-based exclusion (e.g., "integration:GitHub-*" "page:_*")')
+  .option('--include-pages <ids...>', 'Only export these page IDs (whitelist)')
+  .option('--include-actions <ids...>', 'Only export these action IDs (whitelist)')
+  .option('--include-blueprints <ids...>', 'Only export these blueprint IDs (whitelist)')
   .option('--generate-fix-script', 'Generate fix_generated.sh with sed commands for remaining issues')
   .option('--report', 'Generate migration_report.md with summary of exported resources and issues')
   .option('--terraform', 'Run terraform plan -generate-config-out=generated.tf and apply fixes automatically')
@@ -185,6 +189,9 @@ async function main() {
     excludeSystemBlueprints: options.excludeSystemBlueprints || false,
     excludeAiPages: options.excludeAiPages || false,
     excludePatterns: options.exclude || [],
+    includePages: options.includePages,
+    includeActions: options.includeActions,
+    includeBlueprints: options.includeBlueprints,
   };
 
   if (!PORT_CLIENT_ID || !PORT_CLIENT_SECRET) {
@@ -236,6 +243,7 @@ async function main() {
     }
 
     // Apply filters
+    let filteredActions = filterActions(actions.actions, filterOptions);
     let filteredIntegrations = filterIntegrations(integrations.integrations, filterOptions);
     let filteredBlueprints = filterBlueprints(blueprints.blueprints, filterOptions);
     let filteredPages = filterPages(pages.pages, filterOptions);
@@ -298,7 +306,7 @@ async function main() {
     }
 
     console.log('generating tf import files');
-    const actionImports = await generateActionImports(actions.actions, providerAlias);
+    const actionImports = await generateActionImports(filteredActions, providerAlias);
     const blueprintImports = await generateBlueprintImports(filteredBlueprints, providerAlias);
     const aggregationPropertyImports = await generateAggregationPropertyImports(filteredBlueprints, providerAlias);
     const scorecardImports = await generateScorecardImports(scorecards.scorecards, providerAlias);
@@ -362,7 +370,7 @@ async function main() {
 
       const resourceCounts = {
         blueprints: filteredBlueprints.length,
-        actions: actions.actions.length,
+        actions: filteredActions.length,
         pages: filteredPages.length,
         integrations: filteredIntegrations.length,
         scorecards: scorecards.scorecards.length,

--- a/src/tf_import_block_generator.ts
+++ b/src/tf_import_block_generator.ts
@@ -28,6 +28,9 @@ export interface FilterOptions {
     excludeSystemBlueprints?: boolean;
     excludeAiPages?: boolean;
     excludePatterns?: string[];
+    includePages?: string[];
+    includeActions?: string[];
+    includeBlueprints?: string[];
 }
 
 // Blueprint dependency for depends_on generation
@@ -599,6 +602,11 @@ export function filterBlueprints(
     options: FilterOptions
 ): PortBlueprint[] {
     return blueprints.filter(blueprint => {
+        // Strict whitelist: only include specified blueprints
+        if (options.includeBlueprints && options.includeBlueprints.length > 0) {
+            return options.includeBlueprints.includes(blueprint.identifier);
+        }
+
         // Exclude system blueprints (only if flag is set - they are still imported by default for reference)
         if (options.excludeSystemBlueprints && isSystemBlueprint(blueprint.identifier)) {
             return false;
@@ -617,6 +625,17 @@ export function filterBlueprints(
     });
 }
 
+// Filter actions based on filter options
+export function filterActions(
+    actions: PortAction[],
+    options: FilterOptions
+): PortAction[] {
+    if (!options.includeActions || options.includeActions.length === 0) {
+        return actions;
+    }
+    return actions.filter(action => options.includeActions!.includes(action.identifier));
+}
+
 // Filter pages based on filter options
 export function filterPages(
     pages: PortPage[],
@@ -626,6 +645,11 @@ export function filterPages(
         // Skip system pages
         if (page.identifier.startsWith('$') || page.identifier.startsWith('_')) {
             return true; // Let the normal import logic handle these
+        }
+
+        // Strict whitelist: only include specified pages
+        if (options.includePages && options.includePages.length > 0) {
+            return options.includePages.includes(page.identifier);
         }
 
         // Exclude unsupported entity type pages


### PR DESCRIPTION
## Summary

- Adds `--include-pages <ids...>`, `--include-actions <ids...>`, `--include-blueprints <ids...>` flags
- Each flag acts as a strict whitelist — only the specified IDs are exported, everything else is dropped
- Options are independent and composable with each other
- Also removes stale entity page type entry from the fix script docs

## Test plan

- [ ] `--include-pages id1 id2` exports only those two pages
- [ ] `--include-blueprints service` exports only the `service` blueprint
- [ ] `--include-actions deploy` exports only the `deploy` action
- [ ] Omitting any include flag preserves existing behavior (no regression)
- [ ] Flags can be combined: `--include-blueprints service --include-pages overview`

🤖 Generated with [Claude Code](https://claude.com/claude-code)